### PR TITLE
feat(notifications): notify requester when join request is approved o…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model User {
   joinRequests     JoinRequest[] @relation("RequesterJoinRequests")
   ratingsGiven     Rating[]      @relation("RatingsGiven")
   ratingsReceived  Rating[]      @relation("RatingsReceived")
+  notifications    Notification[]
 }
 
 model Activity {
@@ -86,9 +87,10 @@ model Activity {
   cancellationReason  String?
   createdAt           DateTime       @default(now())
 
-  host         User          @relation("HostedActivities", fields: [hostId], references: [id])
-  joinRequests JoinRequest[]
-  ratings      Rating[]
+  host          User           @relation("HostedActivities", fields: [hostId], references: [id])
+  joinRequests  JoinRequest[]
+  ratings       Rating[]
+  notifications Notification[]
 }
 
 enum ActivityStatus {
@@ -131,4 +133,16 @@ model Rating {
   activity Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
 
   @@unique([raterId, rateeId, activityId])
+}
+
+model Notification {
+  id         String   @id @default(cuid())
+  userId     String
+  type       String   // "request_approved" | "request_declined"
+  activityId String
+  read       Boolean  @default(false)
+  createdAt  DateTime @default(now())
+
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  activity Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
 }

--- a/src/app/requests/page.tsx
+++ b/src/app/requests/page.tsx
@@ -11,6 +11,24 @@ export default async function MyRequestsPage() {
   const session = await auth();
   if (!session?.user?.id) redirect("/");
 
+  // Fetch unread notifications and mark them as read atomically
+  const unreadNotifications = await db.notification.findMany({
+    where: { userId: session.user.id, read: false },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      type: true,
+      activity: { select: { id: true, title: true } },
+    },
+  });
+
+  if (unreadNotifications.length > 0) {
+    await db.notification.updateMany({
+      where: { id: { in: unreadNotifications.map((n) => n.id) } },
+      data: { read: true },
+    });
+  }
+
   const requests = await db.joinRequest.findMany({
     where: { userId: session.user.id },
     orderBy: { createdAt: "desc" },
@@ -71,6 +89,56 @@ export default async function MyRequestsPage() {
         >
           My Requests
         </h1>
+
+        {unreadNotifications.length > 0 && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
+            {unreadNotifications.map((n) => {
+              const approved = n.type === "request_approved";
+              return (
+                <Link
+                  key={n.id}
+                  href={`/activities/${n.activity.id}`}
+                  style={{ textDecoration: "none" }}
+                >
+                  <div
+                    style={{
+                      padding: "12px 16px",
+                      borderRadius: 12,
+                      background: approved ? "rgba(45,212,168,0.1)" : "var(--fuchsia-bg)",
+                      border: approved
+                        ? "1px solid rgba(45,212,168,0.35)"
+                        : "1px solid var(--border)",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                    }}
+                  >
+                    <span style={{ fontSize: 18 }}>{approved ? "✅" : "❌"}</span>
+                    <p
+                      style={{
+                        fontFamily: "var(--font-body)",
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: approved ? "#2DD4A8" : "var(--text-secondary)",
+                        margin: 0,
+                      }}
+                    >
+                      Your request to{" "}
+                      <span style={{ color: "var(--text-primary)" }}>
+                        {n.activity.title}
+                      </span>{" "}
+                      was{" "}
+                      <span style={{ color: approved ? "#2DD4A8" : "var(--fuchsia)" }}>
+                        {approved ? "approved" : "declined"}
+                      </span>
+                      {" "}→
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
 
         {requests.length === 0 ? (
           <div

--- a/src/lib/join-request-update.test.ts
+++ b/src/lib/join-request-update.test.ts
@@ -10,6 +10,9 @@ vi.mock('@/lib/db', () => ({
     activity: {
       update: vi.fn(),
     },
+    notification: {
+      create: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -21,6 +24,7 @@ import { updateJoinRequestStatus } from './join-request';
 const mockFindUnique = db.joinRequest.findUnique as any;
 const mockUpdate = db.joinRequest.update as any;
 const mockActivityUpdate = db.activity.update as any;
+const mockNotificationCreate = db.notification.create as any;
 const mockTransaction = db.$transaction as any;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -113,6 +117,7 @@ describe('updateJoinRequestStatus', () => {
   it('successfully approves a pending request', async () => {
     mockFindUnique.mockResolvedValue(mockJoinRequest);
     mockUpdate.mockResolvedValue({ ...mockJoinRequest, status: 'approved' });
+    mockNotificationCreate.mockResolvedValue({});
 
     const result = await updateJoinRequestStatus('jr-1', 'host-1', 'approved');
 
@@ -120,6 +125,9 @@ describe('updateJoinRequestStatus', () => {
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: 'jr-1' },
       data: { status: 'approved' },
+    });
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      data: { userId: 'user-1', type: 'request_approved', activityId: 'activity-1' },
     });
   });
 
@@ -133,12 +141,16 @@ describe('updateJoinRequestStatus', () => {
       },
     });
     mockTransaction.mockResolvedValue([]);
+    mockNotificationCreate.mockResolvedValue({});
 
     await updateJoinRequestStatus('jr-1', 'host-1', 'approved');
 
     expect(mockTransaction).toHaveBeenCalled();
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockActivityUpdate).toHaveBeenCalled();
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      data: { userId: 'user-1', type: 'request_approved', activityId: 'activity-1' },
+    });
   });
 
   it('does not flip activity status when spots remain after approval', async () => {
@@ -151,11 +163,13 @@ describe('updateJoinRequestStatus', () => {
       },
     });
     mockUpdate.mockResolvedValue({ ...mockJoinRequest, status: 'approved' });
+    mockNotificationCreate.mockResolvedValue({});
 
     await updateJoinRequestStatus('jr-1', 'host-1', 'approved');
 
     expect(mockTransaction).not.toHaveBeenCalled();
     expect(mockUpdate).toHaveBeenCalled();
+    expect(mockActivityUpdate).not.toHaveBeenCalled();
   });
 
   it('does not flip activity status when declining at capacity', async () => {
@@ -168,15 +182,20 @@ describe('updateJoinRequestStatus', () => {
       },
     });
     mockUpdate.mockResolvedValue({ ...mockJoinRequest, status: 'declined' });
+    mockNotificationCreate.mockResolvedValue({});
 
     await updateJoinRequestStatus('jr-1', 'host-1', 'declined');
 
     expect(mockActivityUpdate).not.toHaveBeenCalled();
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      data: { userId: 'user-1', type: 'request_declined', activityId: 'activity-1' },
+    });
   });
 
   it('successfully declines a pending request', async () => {
     mockFindUnique.mockResolvedValue(mockJoinRequest);
     mockUpdate.mockResolvedValue({ ...mockJoinRequest, status: 'declined' });
+    mockNotificationCreate.mockResolvedValue({});
 
     const result = await updateJoinRequestStatus('jr-1', 'host-1', 'declined');
 
@@ -184,6 +203,9 @@ describe('updateJoinRequestStatus', () => {
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: 'jr-1' },
       data: { status: 'declined' },
+    });
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      data: { userId: 'user-1', type: 'request_declined', activityId: 'activity-1' },
     });
   });
 });

--- a/src/lib/join-request.ts
+++ b/src/lib/join-request.ts
@@ -156,6 +156,14 @@ export async function updateJoinRequestStatus(
     });
   }
 
+  await db.notification.create({
+    data: {
+      userId: joinRequest.userId,
+      type: newStatus === "approved" ? "request_approved" : "request_declined",
+      activityId: joinRequest.activityId,
+    },
+  });
+
   return { success: true };
 }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                           - Add `Notification` model to Prisma schema (userId, type, activityId, read)                                                                         - Create a notification record when a host approves or declines a join request                                                                       - Show unread notification banners on My Requests page with approve/decline status and a link to the activity                                        - Mark notifications as read on first page visit                                                                                                                                                                                                                                                          ## Test plan                                                                                                                                         - [x] Approved request → requester sees green "approved" banner on /requests                                                                         - [x] Declined request → requester sees fuchsia "declined" banner on /requests                                                                       - [x] Banners disappear after refreshing (marked as read)                                                                                            - [x] No banners shown for pending-only requests                                                                                                   
  - [x] Request status badges still render correctly (no regression)