### PR TITLE
feat(profile): add activity stats badges to public profile page

### DIFF
--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
+import { getProfileStats } from "@/lib/profile";
 import Image from "next/image";
 
 interface Props {
@@ -9,18 +10,19 @@ interface Props {
 export default async function PublicProfilePage({ params }: Props) {
   const { id } = await params;
 
-  const user = await db.user.findUnique({
-    where: { id },
-    select: {
-      name: true,
-      bio: true,
-      image: true,
-      interests: true,
-      location: true,
-      activityCount: true,
-      rating: true,
-    },
-  });
+  const [user, stats] = await Promise.all([
+    db.user.findUnique({
+      where: { id },
+      select: {
+        name: true,
+        bio: true,
+        image: true,
+        interests: true,
+        location: true,
+      },
+    }),
+    getProfileStats(id),
+  ]);
 
   if (!user) notFound();
 
@@ -127,48 +129,49 @@ export default async function PublicProfilePage({ params }: Props) {
           </div>
         )}
 
-        {/* Stats */}
-        <div
-          style={{
-            display: "flex",
-            gap: 24,
-            padding: "12px 24px",
-            borderRadius: 12,
-            background: "var(--fuchsia-bg)",
-            border: "1px solid rgba(255,45,155,0.1)",
-          }}
-        >
-          <div style={{ textAlign: "center" }}>
-            <p
-              style={{
-                fontFamily: "var(--font-outfit), sans-serif",
-                fontWeight: 800,
-                fontSize: 22,
-                color: "var(--fuchsia)",
-              }}
-            >
-              {user.activityCount}
-            </p>
-            <p style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-body)" }}>
-              activities
-            </p>
-          </div>
-          <div style={{ width: 1, background: "rgba(255,45,155,0.15)" }} />
-          <div style={{ textAlign: "center" }}>
-            <p
-              style={{
-                fontFamily: "var(--font-outfit), sans-serif",
-                fontWeight: 800,
-                fontSize: 22,
-                color: "var(--fuchsia)",
-              }}
-            >
-              {user.rating ? user.rating.toFixed(1) : "New"}
-            </p>
-            <p style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-body)" }}>
-              {user.rating ? "rating" : "no ratings yet"}
-            </p>
-          </div>
+        {/* Stats badges */}
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "center" }}>
+          <span
+            style={{
+              padding: "6px 16px",
+              borderRadius: "100px",
+              background: "var(--fuchsia-bg)",
+              border: "1px solid rgba(255,45,155,0.2)",
+              color: "var(--fuchsia)",
+              fontSize: 13,
+              fontFamily: "var(--font-body)",
+              fontWeight: 600,
+            }}
+          >
+            {stats.activitiesHosted} activities hosted
+          </span>
+          <span
+            style={{
+              padding: "6px 16px",
+              borderRadius: "100px",
+              background: "var(--violet-bg)",
+              border: "1px solid rgba(139,92,246,0.2)",
+              color: "var(--violet)",
+              fontSize: 13,
+              fontFamily: "var(--font-body)",
+              fontWeight: 600,
+            }}
+          >
+            {stats.activitiesJoined} activities joined
+          </span>
+          <span
+            style={{
+              padding: "6px 16px",
+              borderRadius: "100px",
+              background: "linear-gradient(135deg, #FF2D9B, #8B5CF6)",
+              color: "#fff",
+              fontSize: 13,
+              fontFamily: "var(--font-body)",
+              fontWeight: 700,
+            }}
+          >
+            ★ {stats.averageRating !== null ? stats.averageRating.toFixed(1) : "—"} avg rating
+          </span>
         </div>
       </div>
     </main>

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    activity: { count: vi.fn() },
+    joinRequest: { count: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import { db } from '@/lib/db';
+import { getProfileStats } from './profile';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockActivityCount = db.activity.count as any;
+const mockJoinRequestCount = db.joinRequest.count as any;
+const mockUserFindUnique = db.user.findUnique as any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe('getProfileStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns activitiesHosted, activitiesJoined, and averageRating for a user', async () => {
+    mockActivityCount.mockResolvedValue(5);
+    mockJoinRequestCount.mockResolvedValue(3);
+    mockUserFindUnique.mockResolvedValue({ rating: 4.2 });
+
+    const result = await getProfileStats('user-1');
+
+    expect(result).toEqual({
+      activitiesHosted: 5,
+      activitiesJoined: 3,
+      averageRating: 4.2,
+    });
+  });
+
+  it('returns averageRating as null for a new user with no ratings', async () => {
+    mockActivityCount.mockResolvedValue(0);
+    mockJoinRequestCount.mockResolvedValue(0);
+    mockUserFindUnique.mockResolvedValue({ rating: null });
+
+    const result = await getProfileStats('user-new');
+
+    expect(result).toEqual({
+      activitiesHosted: 0,
+      activitiesJoined: 0,
+      averageRating: null,
+    });
+  });
+
+  it('queries only approved join requests for activitiesJoined', async () => {
+    mockActivityCount.mockResolvedValue(2);
+    mockJoinRequestCount.mockResolvedValue(1);
+    mockUserFindUnique.mockResolvedValue({ rating: 3.5 });
+
+    await getProfileStats('user-1');
+
+    expect(mockJoinRequestCount).toHaveBeenCalledWith({
+      where: { userId: 'user-1', status: 'approved' },
+    });
+  });
+
+  it('queries activities where user is the host', async () => {
+    mockActivityCount.mockResolvedValue(2);
+    mockJoinRequestCount.mockResolvedValue(1);
+    mockUserFindUnique.mockResolvedValue({ rating: 3.5 });
+
+    await getProfileStats('user-1');
+
+    expect(mockActivityCount).toHaveBeenCalledWith({
+      where: { hostId: 'user-1' },
+    });
+  });
+
+  it('returns averageRating as null when user record is not found', async () => {
+    mockActivityCount.mockResolvedValue(0);
+    mockJoinRequestCount.mockResolvedValue(0);
+    mockUserFindUnique.mockResolvedValue(null);
+
+    const result = await getProfileStats('user-ghost');
+
+    expect(result.averageRating).toBeNull();
+  });
+});

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,21 @@
+import { db } from '@/lib/db';
+
+export interface ProfileStats {
+  activitiesHosted: number;
+  activitiesJoined: number;
+  averageRating: number | null;
+}
+
+export async function getProfileStats(userId: string): Promise<ProfileStats> {
+  const [activitiesHosted, activitiesJoined, user] = await Promise.all([
+    db.activity.count({ where: { hostId: userId } }),
+    db.joinRequest.count({ where: { userId, status: 'approved' } }),
+    db.user.findUnique({ where: { id: userId }, select: { rating: true } }),
+  ]);
+
+  return {
+    activitiesHosted,
+    activitiesJoined,
+    averageRating: user?.rating ?? null,
+  };
+}


### PR DESCRIPTION
Adds hosted count, joined count, and average rating stats to the public profile page. Data fetched via `getProfileStats()` in `src/lib/profile.ts` using parallel Prisma queries.

The old two-stat block (activityCount + rating) is replaced with three pill-shaped badges styled to the design system: fuchsia pill for hosted, violet pill for joined, gradient pill for avg rating.

## Changes
- `src/lib/profile.ts` — new `getProfileStats(userId)` helper; runs 3 Prisma queries in parallel (`activity.count`, `joinRequest.count` for approved only, `user.findUnique` for rating)
- `src/lib/profile.test.ts` — 5 unit tests covering happy path, new user (null rating), query correctness for approved-only and hostId filters
- `src/app/user/[id]/page.tsx` — replaces old stats block with 3 pill badges

## Test plan
- [ ] Visit `/user/[any-user-id]` and confirm 3 stat badges appear below the user name
- [ ] Verify hosted count matches the number of activities the user created
- [ ] Verify joined count matches their approved join requests (not pending/declined)
- [ ] Verify avg rating badge shows `★ — avg rating` for users with no ratings
- [ ] Verify avg rating badge shows the correct value (e.g. `★ 4.2 avg rating`) for rated users
- [ ] Confirm badge styles: fuchsia pill / violet pill / gradient pill all render correctly

Closes #48

## AI Disclosure
- AI-generated code: ~75%
- Tool used: Claude Code (claude.ai/code)
- Human review applied: Yes

## C.L.E.A.R. Review
- [ ] Context: Does the PR description clearly explain the problem?
- [ ] Logic: Is the implementation correct and complete?
- [ ] Edge cases: Are error states and edge cases handled?
- [ ] Architecture: Does business logic live in src/lib/ not route handlers?
- [ ] Risk: Any security, performance, or regression concerns?
