### PR TITLE
fix(test): remove invalid argument in profile route tests

### DIFF
--- a/src/app/api/profile/route.test.ts
+++ b/src/app/api/profile/route.test.ts
@@ -40,21 +40,21 @@ describe('GET /api/profile', () => {
   it('returns 401 when not authenticated', async () => {
     mockAuth(auth, null);
     const req = new Request('http://localhost/api/profile');
-    const res = await GET(req);
+    const res = await GET();
     expect(res.status).toBe(401);
   });
 
   it('returns 404 when user profile does not exist', async () => {
     mockDb.user.findUnique.mockResolvedValue(null);
     const req = new Request('http://localhost/api/profile');
-    const res = await GET(req);
+    const res = await GET();
     expect(res.status).toBe(404);
   });
 
   it('returns 200 with profile data for authenticated user', async () => {
     mockDb.user.findUnique.mockResolvedValue(MOCK_USER);
     const req = new Request('http://localhost/api/profile');
-    const res = await GET(req);
+    const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.id).toBe('user-1');


### PR DESCRIPTION
## Summary
- The `GET` handler in `src/app/api/profile/route.ts` takes no parameters, but the test file was passing a `Request` object, causing 3 TypeScript errors
- Also ran `prisma generate` to resolve 6 additional TS errors from the Notification model

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test -- --run` — 162/162 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)